### PR TITLE
fixed failed tests

### DIFF
--- a/contracts/nebula-cluster-factory/src/testing.rs
+++ b/contracts/nebula-cluster-factory/src/testing.rs
@@ -454,21 +454,6 @@ fn test_token_creation_hook() {
                 })
                 .unwrap(),
             })),
-            SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-                contract_addr: h("asset0000"),
-                funds: vec![],
-                msg: to_binary(&ClusterExecuteMsg::UpdateConfig {
-                    owner: Some("owner0000".to_string()),
-                    name: None,
-                    description: None,
-                    cluster_token: None,
-                    pricing_oracle: None,
-                    target_oracle: None,
-                    penalty: None,
-                    target: None,
-                })
-                .unwrap(),
-            })),
             SubMsg {
                 msg: WasmMsg::Instantiate {
                     admin: None,
@@ -577,7 +562,7 @@ fn test_set_cluster_token_hook() {
                 contract_addr: h("asset0000"),
                 funds: vec![],
                 msg: to_binary(&ClusterExecuteMsg::UpdateConfig {
-                    owner: None,
+                    owner: Some(h("owner0000")),
                     name: None,
                     description: None,
                     cluster_token: Some(h("cluster_token0000")),
@@ -710,7 +695,7 @@ fn test_set_cluster_token_hook_without_weight() {
                 contract_addr: h("asset0000"),
                 funds: vec![],
                 msg: to_binary(&ClusterExecuteMsg::UpdateConfig {
-                    owner: None,
+                    owner: Some(h("owner0000")),
                     name: None,
                     description: None,
                     cluster_token: Some(h("cluster_token0000")),

--- a/contracts/nebula-gov/src/tests.rs
+++ b/contracts/nebula-gov/src/tests.rs
@@ -980,7 +980,13 @@ fn failed_execute_poll() {
         result: ContractResult::Err("Error".to_string()),
     };
     let res = reply(deps.as_mut(), mock_env(), reply_msg).unwrap();
-    assert_eq!(res.attributes, vec![attr("action", "failed_poll")]);
+    assert_eq!(
+        res.attributes,
+        vec![
+            attr("action", "failed_poll"),
+            attr("error", "Error".to_string())
+        ]
+    );
 
     let res = query(deps.as_ref(), mock_env(), QueryMsg::Poll { poll_id: 1 }).unwrap();
     let poll_res: PollResponse = from_binary(&res).unwrap();


### PR DESCRIPTION
fixed minor failed test cases in `nebula-gov` and `nebula-cluster-factory`

`nebula-gov`
- `failed_poll` response contains an `error` attribute which is not present in the test case

`nebula-cluster-factory`
- both the cluster's `owner` and `cluster_token` values are set in `set_cluster_token_hook` but the test case expect `owner` to be set in `token_creation_hook` and only `cluster_token` to be set in `set_cluster_token_hook`
- both should nevertheless be identical functionality-wise since `token_creation_hook` and `set_cluster_token_hook` are always called together and consecutively
