### PR TITLE
Execute messages from community

### DIFF
--- a/packages/nebula_protocol/src/community.rs
+++ b/packages/nebula_protocol/src/community.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use astroport::asset::Asset;
+use cosmwasm_std::Binary;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -18,6 +19,10 @@ pub enum ExecuteMsg {
     Spend {
         asset: Asset,
         recipient: String,
+    },
+    PassCommand {
+        contract_addr: String,
+        msg: Binary,
     },
 }
 


### PR DESCRIPTION
Fixes: #108 

- Execute messages from community if info.sender is the contract owner (gov)